### PR TITLE
[FEAT, REFACTOR] 앱 테마별 색상 사용 기능 구현

### DIFF
--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/AppTheme.kt
@@ -1,0 +1,7 @@
+package com.pickpoint.pickpoint.ui.theme
+
+enum class AppTheme {
+    //전체 테마는 Light, Dark로 구분하고, 추가되는 Point에 해당하는 이름을 뒤에 붙여서 작성
+    LIGHT_PROTOTYPE,
+    DARK_PROTOTYPE
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Color.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Color.kt
@@ -2,10 +2,13 @@ package com.pickpoint.pickpoint.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+//홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등)
+val PrototypePrimaryColor = Color(0xFFEEEEEE)
+//홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등) 에서의 텍스트, 아이콘 등의 색상
+val PrototypeOnPrimaryColor = Color(0xFF333333)
+//기본 배경화면 색상
+val PrototypeBackgroundColor = Color(0xFFFFFFFF)
+//Top App Bar 텍스트 색상
+val ProtorypeSecondaryColor = Color(0xFF555555)
+//HorizontalDivider 색상
+val PrototypeTertiaryColor = Color(0xFFD9D9D9)

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Color.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Color.kt
@@ -2,13 +2,31 @@ package com.pickpoint.pickpoint.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+/*
+* LIGHT_PROTOTYPE 에서 사용할 색상들
+* */
 //홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등)
-val PrototypePrimaryColor = Color(0xFFEEEEEE)
+val LightPrototypePrimaryColor = Color(0xFFEEEEEE)
 //홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등) 에서의 텍스트, 아이콘 등의 색상
-val PrototypeOnPrimaryColor = Color(0xFF333333)
+val LightPrototypeOnPrimaryColor = Color(0xFF333333)
 //기본 배경화면 색상
-val PrototypeBackgroundColor = Color(0xFFFFFFFF)
+val LightPrototypeBackgroundColor = Color(0xFFFFFFFF)
 //Top App Bar 텍스트 색상
-val ProtorypeSecondaryColor = Color(0xFF555555)
+val LightPrototypeSecondaryColor = Color(0xFF555555)
 //HorizontalDivider 색상
-val PrototypeTertiaryColor = Color(0xFFD9D9D9)
+val LightPrototypeTertiaryColor = Color(0xFFD9D9D9)
+
+/*
+* DARK_PROTOTYPE 에서 사용할 색상들
+* TODO: 색상 지정
+* */
+//홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등)
+val DarkPrototypePrimaryColor = Color(0xFFEEEEEE)
+//홈화면 버튼, 각종 컨테이너 (설정, bottom sheet 등) 에서의 텍스트, 아이콘 등의 색상
+val DarkPrototypeOnPrimaryColor = Color(0xFF333333)
+//기본 배경화면 색상
+val DarkPrototypeBackgroundColor = Color(0xFFFFFFFF)
+//Top App Bar 텍스트 색상
+val DarkPrototypeSecondaryColor = Color(0xFF555555)
+//HorizontalDivider 색상
+val DarkPrototypeTertiaryColor = Color(0xFFD9D9D9)

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
@@ -19,7 +19,7 @@ data class PointColors(
     val pointTextColor : Color,
 )
 
-val PrototypePointColors = PointColors(
+val LightPrototypePointColors = PointColors(
      pointColor1 = Color(0xFFFF9900),
      pointColor2 = Color(0xFF7FACFF),
      pointColor3 = Color(0xFF90DBA6),
@@ -33,4 +33,19 @@ val PrototypePointColors = PointColors(
      pointTextColor = Color(0xFFFFFFFF)
 )
 
-val LocalPointColors = staticCompositionLocalOf { PrototypePointColors }
+
+val DarkPrototypePointColors = PointColors(
+    pointColor1 = Color(0xFFFF9900),
+    pointColor2 = Color(0xFF7FACFF),
+    pointColor3 = Color(0xFF90DBA6),
+    pointColor4 = Color(0xFFE88081),
+    pointColor5 = Color(0xFFF6FF92),
+    pointColor6 = Color(0xFFD08EFF),
+    pointColor7 = Color(0xFF6DFFF3),
+    pointColor8 = Color(0xFF2C61FF),
+    pointColor9 = Color(0xFFAEAEAE),
+    pointColor10 =Color(0xFF000000),
+    pointTextColor = Color(0xFFFFFFFF)
+)
+
+val LocalPointColors = staticCompositionLocalOf { LightPrototypePointColors }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
@@ -19,6 +19,9 @@ data class PointColors(
     val pointTextColor : Color,
 )
 
+/*
+* LIGHT_PROTOTYPE 에서 사용할 Point 색상들
+* */
 val LightPrototypePointColors = PointColors(
      pointColor1 = Color(0xFFFF9900),
      pointColor2 = Color(0xFF7FACFF),
@@ -34,6 +37,10 @@ val LightPrototypePointColors = PointColors(
 )
 
 
+/*
+* DARK_PROTOTYPE 에서 사용할 Point 색상들
+* TODO: 색상 지정
+* */
 val DarkPrototypePointColors = PointColors(
     pointColor1 = Color(0xFFFF9900),
     pointColor2 = Color(0xFF7FACFF),

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/PointColors.kt
@@ -1,0 +1,36 @@
+package com.pickpoint.pickpoint.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class PointColors(
+    val pointColor1: Color,
+    val pointColor2: Color,
+    val pointColor3: Color,
+    val pointColor4: Color,
+    val pointColor5: Color,
+    val pointColor6: Color,
+    val pointColor7: Color,
+    val pointColor8: Color,
+    val pointColor9: Color,
+    val pointColor10: Color,
+    val pointTextColor : Color,
+)
+
+val PrototypePointColors = PointColors(
+     pointColor1 = Color(0xFFFF9900),
+     pointColor2 = Color(0xFF7FACFF),
+     pointColor3 = Color(0xFF90DBA6),
+     pointColor4 = Color(0xFFE88081),
+     pointColor5 = Color(0xFFF6FF92),
+     pointColor6 = Color(0xFFD08EFF),
+     pointColor7 = Color(0xFF6DFFF3),
+     pointColor8 = Color(0xFF2C61FF),
+     pointColor9 = Color(0xFFAEAEAE),
+     pointColor10 =Color(0xFF000000),
+     pointTextColor = Color(0xFFFFFFFF)
+)
+
+val LocalPointColors = staticCompositionLocalOf { PrototypePointColors }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
@@ -1,14 +1,13 @@
 package com.pickpoint.pickpoint.ui.theme
 
-import android.app.Activity
 import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
@@ -28,26 +27,42 @@ private val LightColorScheme = lightColorScheme(
     tertiary = PrototypeTertiaryColor
 )
 
+enum class AppTheme {
+    LIGHT_PROTOTYPE,
+    DARK_PROTOTYPE
+}
+
 @Composable
 fun PickPointTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    theme: AppTheme = AppTheme.LIGHT_PROTOTYPE,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val context = LocalContext.current
+    val isDarkTheme = when (theme) {
+        AppTheme.DARK_PROTOTYPE -> true
+        else -> false
+    }
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (isDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
-        darkTheme -> DarkColorScheme
+        isDarkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    val pointColors = when (theme){
+        AppTheme.LIGHT_PROTOTYPE -> LightPrototypePointColors
+        AppTheme.DARK_PROTOTYPE -> DarkPrototypePointColors
+        else -> LightPrototypePointColors
+    }
+
+    CompositionLocalProvider(LocalPointColors provides pointColors) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
@@ -12,25 +12,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    //TODO: 다크모드 색상 지정
+    primary = PrototypePrimaryColor,
+    onPrimary = PrototypeOnPrimaryColor,
+    background = PrototypeBackgroundColor,
+    secondary = ProtorypeSecondaryColor,
+    tertiary = PrototypeTertiaryColor
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = PrototypePrimaryColor,
+    onPrimary = PrototypeOnPrimaryColor,
+    background = PrototypeBackgroundColor,
+    secondary = ProtorypeSecondaryColor,
+    tertiary = PrototypeTertiaryColor
 )
 
 @Composable

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
@@ -27,10 +27,6 @@ private val LightColorScheme = lightColorScheme(
     tertiary = PrototypeTertiaryColor
 )
 
-enum class AppTheme {
-    LIGHT_PROTOTYPE,
-    DARK_PROTOTYPE
-}
 
 @Composable
 fun PickPointTheme(
@@ -42,6 +38,7 @@ fun PickPointTheme(
     val context = LocalContext.current
     val isDarkTheme = when (theme) {
         AppTheme.DARK_PROTOTYPE -> true
+        AppTheme.LIGHT_PROTOTYPE -> false
         else -> false
     }
     val colorScheme = when {

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/theme/Theme.kt
@@ -11,20 +11,19 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    //TODO: 다크모드 색상 지정
-    primary = PrototypePrimaryColor,
-    onPrimary = PrototypeOnPrimaryColor,
-    background = PrototypeBackgroundColor,
-    secondary = ProtorypeSecondaryColor,
-    tertiary = PrototypeTertiaryColor
+    primary = DarkPrototypePrimaryColor,
+    onPrimary = DarkPrototypeOnPrimaryColor,
+    background = DarkPrototypeBackgroundColor,
+    secondary = DarkPrototypeSecondaryColor,
+    tertiary = DarkPrototypeTertiaryColor
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = PrototypePrimaryColor,
-    onPrimary = PrototypeOnPrimaryColor,
-    background = PrototypeBackgroundColor,
-    secondary = ProtorypeSecondaryColor,
-    tertiary = PrototypeTertiaryColor
+    primary = LightPrototypePrimaryColor,
+    onPrimary = LightPrototypeOnPrimaryColor,
+    background = LightPrototypeBackgroundColor,
+    secondary = LightPrototypeSecondaryColor,
+    tertiary = LightPrototypeTertiaryColor
 )
 
 


### PR DESCRIPTION
## 변경 사항 요약
테마 설정을 위한 theme 관련 파일들 작성

## 변경 사항
- [x] 테마 관리를 위한 enum class AppTheme 작성
- [x] light, dark 모드에서 사용할 앱 색상들을 Color.kt에 작성
- [x] 각 테마에서 사용할 Point의 색상들을 PointColors.kt에 작성
- [x] 테마별 색상 적용을 위해 Theme.kt 작성

## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- #10


## 참고사항 (이미지/동영상 등 필요시 첨부)
- dark 모드 관련 색상들은 light랑 동일하게 되어있어서 추후 수정 필요
- 크게 light, dark 모드 두 가지로 분류가 되고, 예를 들어서 그 안에서 선택할 수 있는 Point 색상 집합 이름을 Prototype이라고 할 때, LIGHT_PROTOTYPE, DARK_PROTOTYPE 과 같이 AppTheme에 추가하고, 사용할 Point 색상 집합을 PointColors.kt에 작성한다. 이 작업이 끝나면 Theme.kt에서 val pointColors에 해당하는 부분에 규칙에 맞게 작성하면 된다.

```kotlin
@Composable
fun MyScreen() {
    val pointColors = LocalPointColors.current

    Column(
        modifier = Modifier
            .fillMaxSize()
            .background(pointColors.pointColor1)
    )
}
```
- 이런식으로 PointColors 를 불러와서 사용할 수 있다.