### PR TITLE
[Feat] Setting 정보를 내부 데이터에 저장하는 기능을 구현한다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,5 +57,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
     implementation(libs.androidx.datastore.preferences)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,4 +56,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/app/src/main/java/com/pickpoint/pickpoint/MainActivity.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.pickpoint.pickpoint.ui.common.util.DataStoreManager
 import com.pickpoint.pickpoint.ui.home.screen.HomeScreen
+import com.pickpoint.pickpoint.ui.home.viewmodel.HomeViewModel
 import com.pickpoint.pickpoint.ui.theme.PickPointTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,7 +22,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PickPointTheme {
-                HomeScreen()
+                val dataStoreManager = DataStoreManager(context = this)
+                val homeViewModel = HomeViewModel(dataStoreManager = dataStoreManager)
+                HomeScreen(viewModel = homeViewModel)
             }
         }
     }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/SettingComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/SettingComponent.kt
@@ -1,6 +1,7 @@
 package com.pickpoint.pickpoint.ui.common.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,11 +14,17 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -25,6 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pickpoint.pickpoint.R
+import com.pickpoint.pickpoint.ui.model.setting.ThemeSetting
 
 /**
  * @param*/
@@ -32,8 +40,9 @@ import com.pickpoint.pickpoint.R
 fun SettingComponent(
     modifier: Modifier = Modifier,
     title: String = "",
-    settingMenus: List<String>,
+    settingRes: List<Int>,
     checkedIndex: Int = 0,
+    onClick : (Int) -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -43,7 +52,7 @@ fun SettingComponent(
     ) {
         Row(
             modifier = Modifier
-                .height(23.dp)
+                .height(36.dp)
         ) {
             Text(
                 text = title,
@@ -65,17 +74,19 @@ fun SettingComponent(
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .background(color = Color(0xFFEEEEEE), shape = RoundedCornerShape(size = 8.dp))
-                .padding(10.dp)
         ) {
-            settingMenus.forEachIndexed { index, menu ->
+            settingRes.forEachIndexed { index, res ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clip(RoundedCornerShape(size = 8.dp))
+                        .clickable { onClick(index) }
+                        .padding(10.dp)
                         .height(24.dp),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        text = menu,
+                        text = stringResource(id = res),
                         modifier = Modifier
                             .align(Alignment.CenterVertically),
                         style = TextStyle(
@@ -92,11 +103,11 @@ fun SettingComponent(
                         )
                     }
                 }
-                if (index != settingMenus.size - 1) {
+                if (index != settingRes.size - 1) {
                     HorizontalDivider(
                         modifier = Modifier
+                            .padding(horizontal = 10.dp)
                             .fillMaxWidth()
-                            .padding(vertical = 6.dp)
                     )
                 }
             }
@@ -107,10 +118,13 @@ fun SettingComponent(
 @Preview(showBackground = true)
 @Composable
 private fun SettingComponentPreview() {
+    var checkedIndex by remember { mutableIntStateOf(0) }
+
     SettingComponent(
         title = "Language",
-        settingMenus = listOf("한국어 (대한민국)", "English", "日本語"),
-        checkedIndex = 0
+        settingRes = ThemeSetting.entries.map { it.res },
+        checkedIndex = checkedIndex,
+        onClick = { checkedIndex = it }
     )
 }
 
@@ -123,7 +137,7 @@ private fun SettingComponentPreview() {
 private fun SettingComponentPreviewFull() {
     SettingComponent(
         title = "Language",
-        settingMenus = listOf("한국어 (대한민국)", "English", "日本語"),
+        settingRes = ThemeSetting.entries.map { it.res },
         checkedIndex = 0
     )
 }
@@ -137,7 +151,7 @@ private fun SettingComponentPreviewFull() {
 private fun SettingComponentPreviewWide() {
     SettingComponent(
         title = "Language",
-        settingMenus = listOf("한국어 (대한민국)", "English", "日本語"),
+        settingRes = ThemeSetting.entries.map { it.res },
         checkedIndex = 0
     )
 }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
@@ -5,6 +5,9 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.pickpoint.pickpoint.ui.model.setting.LanguageSetting
+import com.pickpoint.pickpoint.ui.model.setting.PreferencesSetting
+import com.pickpoint.pickpoint.ui.model.setting.ThemeSetting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -18,25 +21,36 @@ class DataStoreManager(private val context: Context) {
     private val languageKey = stringPreferencesKey("language")
     private val preferencesKey = stringPreferencesKey("preferences")
 
-    suspend fun setThemeSetting(text: String) {
+    suspend fun saveThemeSetting(setting: ThemeSetting) {
         context.dataStore.edit { theme ->
-            theme[themeKey] = text
+            theme[themeKey] = when (setting) {
+                ThemeSetting.PROTOTYPE -> ThemeSetting.PROTOTYPE.value
+                ThemeSetting.COMING_SOON -> ThemeSetting.COMING_SOON.value
+            }
         }
     }
 
-    suspend fun setLanguageSetting(text: String) {
+    suspend fun saveLanguageSetting(setting: LanguageSetting) {
         context.dataStore.edit { language ->
-            language[languageKey] = text
+            language[languageKey] = when (setting) {
+                LanguageSetting.KOREAN -> LanguageSetting.KOREAN.value
+                LanguageSetting.ENGLISH -> LanguageSetting.ENGLISH.value
+                LanguageSetting.JAPANESE -> LanguageSetting.JAPANESE.value
+            }
         }
     }
 
-    suspend fun setPreferencesSetting(text: String) {
+    suspend fun savePreferencesSetting(setting: PreferencesSetting) {
         context.dataStore.edit { preferences ->
-            preferences[preferencesKey] = text
+            preferences[preferencesKey] = when (setting) {
+                PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS.value
+                PreferencesSetting.SOME_SETTINGS -> PreferencesSetting.SOME_SETTINGS.value
+            }
         }
     }
 
-    fun getThemeSetting(): Flow<String> {
+    fun getThemeSetting(): Flow<ThemeSetting> {
+
         return context.dataStore.data
             .catch { exception ->
                 if (exception is IOException) {
@@ -46,11 +60,15 @@ class DataStoreManager(private val context: Context) {
                 }
             }
             .map { preferences ->
-                preferences[themeKey] ?: "prototype"
+                when (preferences[themeKey]) {
+                    ThemeSetting.PROTOTYPE.value -> ThemeSetting.PROTOTYPE
+                    ThemeSetting.COMING_SOON.value -> ThemeSetting.COMING_SOON
+                    else -> ThemeSetting.PROTOTYPE
+                }
             }
     }
 
-    fun getLanguageSetting(): Flow<String> {
+    fun getLanguageSetting(): Flow<LanguageSetting> {
         return context.dataStore.data
             .catch { exception ->
                 if (exception is IOException) {
@@ -60,11 +78,16 @@ class DataStoreManager(private val context: Context) {
                 }
             }
             .map { preferences ->
-                preferences[languageKey] ?: "한국어 (대한민국)"
+                when (preferences[languageKey]) {
+                    LanguageSetting.KOREAN.value -> LanguageSetting.KOREAN
+                    LanguageSetting.ENGLISH.value -> LanguageSetting.ENGLISH
+                    LanguageSetting.JAPANESE.value -> LanguageSetting.JAPANESE
+                    else -> LanguageSetting.KOREAN
+                }
             }
     }
 
-    fun getPreferencesSetting(): Flow<String> {
+    fun getPreferencesSetting(): Flow<PreferencesSetting> {
         return context.dataStore.data
             .catch { exception ->
                 if (exception is IOException) {
@@ -74,7 +97,11 @@ class DataStoreManager(private val context: Context) {
                 }
             }
             .map { preferences ->
-                preferences[preferencesKey] ?: "Remember Previous Settings"
+                when (preferences[preferencesKey]) {
+                    PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS.value -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS
+                    PreferencesSetting.SOME_SETTINGS.value -> PreferencesSetting.SOME_SETTINGS
+                    else -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS
+                }
             }
     }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
@@ -1,0 +1,81 @@
+package com.pickpoint.pickpoint.ui.common.util
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+
+private val Context.dataStore by preferencesDataStore(name = "dataStore")
+
+class DataStoreManager(private val context: Context) {
+
+    private val themeKey = stringPreferencesKey("theme")
+    private val languageKey = stringPreferencesKey("language")
+    private val preferencesKey = stringPreferencesKey("preferences")
+
+    suspend fun setThemeSetting(text: String) {
+        context.dataStore.edit { theme ->
+            theme[themeKey] = text
+        }
+    }
+
+    suspend fun setLanguageSetting(text: String) {
+        context.dataStore.edit { language ->
+            language[languageKey] = text
+        }
+    }
+
+    suspend fun setPreferencesSetting(text: String) {
+        context.dataStore.edit { preferences ->
+            preferences[preferencesKey] = text
+        }
+    }
+
+    fun getThemeSetting(): Flow<String> {
+        return context.dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[themeKey] ?: "prototype"
+            }
+    }
+
+    fun getLanguageSetting(): Flow<String> {
+        return context.dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[languageKey] ?: "한국어 (대한민국)"
+            }
+    }
+
+    fun getPreferencesSetting(): Flow<String> {
+        return context.dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[preferencesKey] ?: "Remember Previous Settings"
+            }
+    }
+
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/DataStoreManager.kt
@@ -1,6 +1,7 @@
 package com.pickpoint.pickpoint.ui.common.util
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -21,28 +22,22 @@ class DataStoreManager(private val context: Context) {
     private val languageKey = stringPreferencesKey("language")
     private val preferencesKey = stringPreferencesKey("preferences")
 
-    suspend fun saveThemeSetting(setting: ThemeSetting) {
-        context.dataStore.edit { theme ->
-            theme[themeKey] = when (setting) {
+    suspend fun saveAllSettings(
+        themeSetting: ThemeSetting,
+        languageSetting: LanguageSetting,
+        preferencesSetting: PreferencesSetting
+    ) {
+        context.dataStore.edit { preferences ->
+            preferences[themeKey] = when (themeSetting) {
                 ThemeSetting.PROTOTYPE -> ThemeSetting.PROTOTYPE.value
                 ThemeSetting.COMING_SOON -> ThemeSetting.COMING_SOON.value
             }
-        }
-    }
-
-    suspend fun saveLanguageSetting(setting: LanguageSetting) {
-        context.dataStore.edit { language ->
-            language[languageKey] = when (setting) {
+            preferences[languageKey] = when (languageSetting) {
                 LanguageSetting.KOREAN -> LanguageSetting.KOREAN.value
                 LanguageSetting.ENGLISH -> LanguageSetting.ENGLISH.value
                 LanguageSetting.JAPANESE -> LanguageSetting.JAPANESE.value
             }
-        }
-    }
-
-    suspend fun savePreferencesSetting(setting: PreferencesSetting) {
-        context.dataStore.edit { preferences ->
-            preferences[preferencesKey] = when (setting) {
+            preferences[preferencesKey] = when (preferencesSetting) {
                 PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS.value
                 PreferencesSetting.SOME_SETTINGS -> PreferencesSetting.SOME_SETTINGS.value
             }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/screen/FakeSettingScreen.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/screen/FakeSettingScreen.kt
@@ -1,0 +1,77 @@
+package com.pickpoint.pickpoint.ui.home.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pickpoint.pickpoint.ui.common.component.SettingComponent
+import com.pickpoint.pickpoint.ui.home.viewmodel.HomeViewModel
+import com.pickpoint.pickpoint.ui.model.setting.LanguageSetting
+import com.pickpoint.pickpoint.ui.model.setting.PreferencesSetting
+import com.pickpoint.pickpoint.ui.model.setting.ThemeSetting
+
+@Composable
+fun FakeSettingScreen(
+    modifier: Modifier = Modifier,
+    viewModel: HomeViewModel
+) {
+
+    val themeSettingIndex by viewModel.themeSettingIndex.collectAsStateWithLifecycle()
+    val languageSettingIndex by viewModel.languageSettingIndex.collectAsStateWithLifecycle()
+    val preferencesSettingIndex by viewModel.preferencesSettingIndex.collectAsStateWithLifecycle()
+
+
+    Column(
+        modifier = modifier
+            .clipToBounds()
+    ) {
+        SettingComponent(
+            modifier = Modifier.padding(top = 20.dp),
+            title = "Theme",
+            settingRes = ThemeSetting.entries.map { it.res },
+            checkedIndex = themeSettingIndex,
+            onClick = { viewModel.updateThemeSettingIndex(it) }
+        )
+        SettingComponent(
+            modifier = Modifier.padding(top = 20.dp),
+            title = "Language",
+            settingRes = LanguageSetting.entries.map { it.res },
+            checkedIndex = languageSettingIndex,
+            onClick = { viewModel.updateLanguageSettingIndex(it) }
+        )
+        SettingComponent(
+            modifier = Modifier.padding(top = 20.dp),
+            title = "Preferences",
+            settingRes = PreferencesSetting.entries.map { it.res },
+            checkedIndex = preferencesSettingIndex,
+            onClick = { viewModel.updatePreferencesSettingIndex(it) }
+        )
+        Spacer(Modifier.size(50.dp))
+
+        Row {
+            Button(
+                onClick = { viewModel.resetSettings() },
+                modifier = Modifier.padding(20.dp)
+            ) {
+                Text(text = "Reset")
+            }
+            Spacer(Modifier.size(20.dp))
+
+            Button(
+                onClick = { viewModel.saveSettings() },
+                modifier = Modifier.padding(20.dp)
+            ) {
+                Text(text = "Confirm")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/screen/HomeScreen.kt
@@ -6,9 +6,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.sp
+import com.pickpoint.pickpoint.ui.home.viewmodel.HomeViewModel
 
 @Composable
-fun HomeScreen(modifier: Modifier = Modifier) {
+fun HomeScreen(
+    viewModel: HomeViewModel,
+    modifier: Modifier = Modifier
+) {
     Column(modifier = Modifier.fillMaxSize()) {
         Text(text = "HomeScreen", fontSize = 30.sp)
     }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pickpoint.pickpoint.ui.common.util.DataStoreManager
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class HomeViewModel(
@@ -11,13 +12,44 @@ class HomeViewModel(
 ) : ViewModel() {
 
     private val _themeSetting = MutableStateFlow<String>("")
-    val themeSetting = _themeSetting
+    val themeSetting: StateFlow<String> = _themeSetting
 
     private val _languageSetting = MutableStateFlow<String>("")
-    val languageSetting = _languageSetting
+    val languageSetting: StateFlow<String> = _languageSetting
 
     private val _preferencesSetting = MutableStateFlow<String>("")
-    val preferencesSetting = _preferencesSetting
+    val preferencesSetting: StateFlow<String> = _preferencesSetting
+
+    init {
+        loadSettings()
+    }
+
+    // reset 버튼의 onClick 이벤트로 설정하면 됨.
+    fun resetSettings() {
+        loadSettings()
+    }
+
+    // confirm 버튼의 onClick 이벤트로 설정하면 됨.
+    fun saveSettings() {
+        viewModelScope.launch {
+            saveThemeSettings()
+            saveLanguageSettings()
+            savePreferencesSettings()
+        }
+    }
+
+    private suspend fun saveThemeSettings() {
+        dataStoreManager.setThemeSetting(themeSetting.value)
+    }
+
+    private suspend fun saveLanguageSettings() {
+        dataStoreManager.setLanguageSetting(languageSetting.value)
+    }
+
+    private suspend fun savePreferencesSettings() {
+        dataStoreManager.setPreferencesSetting(preferencesSetting.value)
+    }
+
 
     private fun loadSettings() {
         viewModelScope.launch {

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
@@ -37,23 +37,19 @@ class HomeViewModel(
     // confirm 버튼의 onClick 이벤트로 설정하면 됨.
     fun saveSettings() {
         viewModelScope.launch {
-            dataStoreManager.saveThemeSetting(
-                when (_themeSettingIndex.value) {
+            dataStoreManager.saveAllSettings(
+                when (themeSettingIndex.value) {
                     ThemeSetting.PROTOTYPE.index -> ThemeSetting.PROTOTYPE
                     ThemeSetting.COMING_SOON.index -> ThemeSetting.COMING_SOON
                     else -> ThemeSetting.PROTOTYPE
-                }
-            )
-            dataStoreManager.saveLanguageSetting(
-                when (_languageSettingIndex.value) {
+                },
+                when (languageSettingIndex.value) {
                     LanguageSetting.KOREAN.index -> LanguageSetting.KOREAN
                     LanguageSetting.ENGLISH.index -> LanguageSetting.ENGLISH
                     LanguageSetting.JAPANESE.index -> LanguageSetting.JAPANESE
                     else -> LanguageSetting.KOREAN
-                }
-            )
-            dataStoreManager.savePreferencesSetting(
-                when (_preferencesSettingIndex.value) {
+                },
+                when (preferencesSettingIndex.value) {
                     PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS.index -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS
                     PreferencesSetting.SOME_SETTINGS.index -> PreferencesSetting.SOME_SETTINGS
                     else -> PreferencesSetting.REMEMBER_PREVIOUS_SETTINGS
@@ -64,7 +60,7 @@ class HomeViewModel(
 
 
     private fun loadSettings() {
-
+        Log.d("HomeViewModel", "loadSettings")
         viewModelScope.launch {
             combine(
                 dataStoreManager.getThemeSetting(),
@@ -114,14 +110,20 @@ class HomeViewModel(
 
     fun updateThemeSettingIndex(index: Int) {
         _themeSettingIndex.value = index
+        Log.d("HomeViewModel", "updateThemeSettingIndex: ${themeSettingIndex.value}")
     }
 
     fun updateLanguageSettingIndex(index: Int) {
         _languageSettingIndex.value = index
+        Log.d("HomeViewModel", "updateLanguageSettingIndex: ${languageSettingIndex.value}")
     }
 
     fun updatePreferencesSettingIndex(index: Int) {
         _preferencesSettingIndex.value = index
+        Log.d(
+            "HomeViewModel",
+            "updatePreferencesSettingIndex: ${preferencesSettingIndex.value}"
+        )
     }
 
 }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
@@ -1,0 +1,47 @@
+package com.pickpoint.pickpoint.ui.home.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pickpoint.pickpoint.ui.common.util.DataStoreManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel(
+    private val dataStoreManager: DataStoreManager
+) : ViewModel() {
+
+    private val _themeSetting = MutableStateFlow<String>("")
+    val themeSetting = _themeSetting
+
+    private val _languageSetting = MutableStateFlow<String>("")
+    val languageSetting = _languageSetting
+
+    private val _preferencesSetting = MutableStateFlow<String>("")
+    val preferencesSetting = _preferencesSetting
+
+    private fun loadSettings() {
+        viewModelScope.launch {
+            loadThemeSetting()
+            loadLanguageSetting()
+            loadPreferencesSetting()
+        }
+    }
+
+    private suspend fun loadThemeSetting() {
+        dataStoreManager.getThemeSetting().collect { theme ->
+            _themeSetting.value = theme
+        }
+    }
+
+    private suspend fun loadLanguageSetting() {
+        dataStoreManager.getLanguageSetting().collect { language ->
+            _languageSetting.value = language
+        }
+    }
+
+    private suspend fun loadPreferencesSetting() {
+        dataStoreManager.getPreferencesSetting().collect { preferences ->
+            _preferencesSetting.value = preferences
+        }
+    }
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModel.kt
@@ -112,5 +112,16 @@ class HomeViewModel(
         }
     }
 
+    fun updateThemeSettingIndex(index: Int) {
+        _themeSettingIndex.value = index
+    }
+
+    fun updateLanguageSettingIndex(index: Int) {
+        _languageSettingIndex.value = index
+    }
+
+    fun updatePreferencesSettingIndex(index: Int) {
+        _preferencesSettingIndex.value = index
+    }
 
 }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModelFactory.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/home/viewmodel/HomeViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.pickpoint.pickpoint.ui.home.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.pickpoint.pickpoint.ui.common.util.DataStoreManager
+
+class HomeViewModelFactory(private val dataStoreManager: DataStoreManager) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HomeViewModel::class.java)) {
+            return HomeViewModel(dataStoreManager) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class LanguageSetting(
-    @StringRes val res: Int, val value: String, private val index: Int
+    @StringRes val res: Int, val value: String, val index: Int
 ) {
     KOREAN(R.string.korean, "한국어 (대한민국)", 0),
     ENGLISH(R.string.english, "English", 1),

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
@@ -4,12 +4,11 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class LanguageSetting(
-    @StringRes val value: Int, private val index: Int
+    @StringRes val res: Int, val value: String, private val index: Int
 ) {
-    KOREAN(R.string.korean, 0),
-    ENGLISH(R.string.english, 1),
-    JAPANESE(R.string.japanese, 2);
+    KOREAN(R.string.korean, "한국어 (대한민국)", 0),
+    ENGLISH(R.string.english, "English", 1),
+    JAPANESE(R.string.japanese, "日本語", 2);
 
-    fun getMatchedIndex(index: Int) = index == this.index
 }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/LanguageSetting.kt
@@ -1,0 +1,15 @@
+package com.pickpoint.pickpoint.ui.model.setting
+
+import androidx.annotation.StringRes
+import com.pickpoint.pickpoint.R
+
+enum class LanguageSetting(
+    @StringRes val value: Int, private val index: Int
+) {
+    KOREAN(R.string.korean, 0),
+    ENGLISH(R.string.english, 1),
+    JAPANESE(R.string.japanese, 2);
+
+    fun getMatchedIndex(index: Int) = index == this.index
+}
+

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
@@ -4,11 +4,14 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class PreferencesSetting(
-    @StringRes val value: Int, private val index: Int
+    @StringRes val res: Int, val value: String, private val index: Int
 ) {
-    REMEMBER_PREVIOUS_SETTINGS(R.string.remember_previous_settings, 0),
-    SOME_SETTINGS(R.string.some_settings, 1);
+    REMEMBER_PREVIOUS_SETTINGS(
+        R.string.remember_previous_settings,
+        "Remember Previous Settings",
+        0
+    ),
+    SOME_SETTINGS(R.string.some_settings, "Some Settings", 1);
 
-    fun getMatchedIndex(index: Int) = index == this.index
 }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class PreferencesSetting(
-    @StringRes val res: Int, val value: String, private val index: Int
+    @StringRes val res: Int, val value: String, val index: Int
 ) {
     REMEMBER_PREVIOUS_SETTINGS(
         R.string.remember_previous_settings,

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/PreferencesSetting.kt
@@ -1,0 +1,14 @@
+package com.pickpoint.pickpoint.ui.model.setting
+
+import androidx.annotation.StringRes
+import com.pickpoint.pickpoint.R
+
+enum class PreferencesSetting(
+    @StringRes val value: Int, private val index: Int
+) {
+    REMEMBER_PREVIOUS_SETTINGS(R.string.remember_previous_settings, 0),
+    SOME_SETTINGS(R.string.some_settings, 1);
+
+    fun getMatchedIndex(index: Int) = index == this.index
+}
+

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
@@ -4,11 +4,10 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class ThemeSetting(
-    @StringRes val value: Int, private val index: Int
+    @StringRes val res: Int, val value: String, private val index: Int
 ) {
-    PROTOTYPE(R.string.prototype, 0),
-    COMING_SOON(R.string.coming_soon, 1);
+    PROTOTYPE(R.string.prototype, "prototype", 0),
+    COMING_SOON(R.string.coming_soon, "coming soon...", 1);
 
-    fun getMatchedIndex(index: Int) = index == this.index
 }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
@@ -1,0 +1,14 @@
+package com.pickpoint.pickpoint.ui.model.setting
+
+import androidx.annotation.StringRes
+import com.pickpoint.pickpoint.R
+
+enum class ThemeSetting(
+    @StringRes val value: Int, private val index: Int
+) {
+    PROTOTYPE(R.string.prototype, 0),
+    COMING_SOON(R.string.coming_soon, 1);
+
+    fun getMatchedIndex(index: Int) = index == this.index
+}
+

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/model/setting/ThemeSetting.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import com.pickpoint.pickpoint.R
 
 enum class ThemeSetting(
-    @StringRes val res: Int, val value: String, private val index: Int
+    @StringRes val res: Int, val value: String, val index: Int
 ) {
     PROTOTYPE(R.string.prototype, "prototype", 0),
     COMING_SOON(R.string.coming_soon, "coming soon...", 1);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,17 @@
 <resources>
     <string name="app_name">PickPoint</string>
+
+    <!--  Theme Setting  -->
+    <string name="prototype">prototype</string>
+    <string name="coming_soon">coming soon…</string>
+    
+    <!--  Language Setting  -->
+    <string name="korean">한국어 (대한민국)</string>
+    <string name="english">English</string>
+    <string name="japanese">日本語</string>
+
+    <!--  Preferences Setting  -->
+    <string name="remember_previous_settings">Remember Previous Settings</string>
+    <string name="some_settings">Some Settings</string>
+    
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.0"
+datastorePreferences = "1.1.2"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -11,6 +12,7 @@ composeBom = "2024.04.01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## 변경 사항 요약
- DataStore 에 데이터를 저장하고 관리하는 `**DataStoreManger**` 클래스 구현
- `**HomeViewModel**` 에서 `**DataStoreManger**` 로 데이터를 보내고 가져오는 기능 구현
- Enum 으로 세팅들 관리

## 변경 사항
- [x] ThemeSetting
- [x] LanguageSetting
- [x] PreferenceSetting
- [x] 데이터 저장하기
- [x] 데이터 불러오기


## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- resolves #15 


## 참고사항 (이미지/동영상 등 필요시 첨부)
Data Store 사용법 by Wiki : [Data Store 로 내부 저장소에 데이터를 저장하고 불러오기](https://github.com/Pick-Point/PickPoint/wiki/Data-Store-%EB%A1%9C-%EB%82%B4%EB%B6%80-%EC%A0%80%EC%9E%A5%EC%86%8C%EC%97%90-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A5%BC-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B3%A0-%EB%B6%88%EB%9F%AC%EC%98%A4%EA%B8%B0)


[Data Store Settings.webm](https://github.com/user-attachments/assets/4a92f3fa-6964-43da-a7ee-582339887ef6)


