### PR TITLE
[FEAT] what to do 컴포넌트 작성

### DIFF
--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -180,6 +180,7 @@ private fun WTDGameComponentPreview() {
     PickPointTheme(theme = AppTheme.LIGHT_PROTOTYPE, dynamicColor = false) {
         Column(modifier = Modifier.fillMaxSize()) {
             WTDGameComponent(
+                totalPoints = 5,
                 resultDialog = { onRetry ->
                     Box(
                         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -1,0 +1,202 @@
+package com.pickpoint.pickpoint.ui.whattodo.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.pickpoint.pickpoint.ui.common.component.CircleButton
+import com.pickpoint.pickpoint.ui.common.util.getPointColorList
+import com.pickpoint.pickpoint.ui.common.util.timerStartHandler
+import com.pickpoint.pickpoint.ui.theme.AppTheme
+import com.pickpoint.pickpoint.ui.theme.LocalPointColors
+import com.pickpoint.pickpoint.ui.theme.PickPointTheme
+import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
+
+
+@Composable
+fun WTDGameComponent(
+    modifier: Modifier = Modifier,
+    totalPoints: Int = 3, // 최종적으로 사용할 점의 개수
+    resultDialog: @Composable ((onRetry: () -> Unit) -> Unit)? = null, // 카운트다운 끝난 후 결과 다이얼로그
+) {
+    val pointColorList = LocalPointColors.current.getPointColorList()
+    val pointSize = 100
+    val timeToStart: Long = 2000 //2초
+    val usedColors = remember { mutableStateListOf<Color>() }
+    var countdown by remember { mutableStateOf<Int?>(null) }
+    var isGameActive by remember { mutableStateOf(true) } // 게임 진행 여부
+    var showResultDialog by remember { mutableStateOf(false) } // 결과 다이얼로그 표시 여부
+
+    val (touchPoints, finalPoints) = timerStartHandler(
+        pointsToStart = totalPoints,
+        timeToStart = timeToStart,
+    )
+
+    val resultPoints = remember { mutableStateListOf<Pair<Offset, Color>>() }
+
+    // 카운트다운
+    LaunchedEffect(touchPoints.keys.toSet()) {
+        countdown = null
+        if (touchPoints.size == totalPoints) {
+            delay(timeToStart)
+            for (i in 3 downTo 1) {
+                countdown = i
+                delay(1000)
+            }
+            isGameActive = false
+            countdown = null
+            showResultDialog = true
+
+            finalPoints.clear()
+            finalPoints.addAll(touchPoints.values)
+
+            // 로직 반영
+            resultPoints.clear()
+            resultPoints.addAll(finalPoints.shuffled().take(totalPoints))
+        }
+    }
+
+    val resetGame: () -> Unit = {
+        isGameActive = true
+        showResultDialog = false
+        countdown = null
+        touchPoints.clear()
+        finalPoints.clear()
+        resultPoints.clear()
+        usedColors.clear()
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            // pointerInput을 이용해 터치 이벤트를 감지
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        if (event.changes.size <= totalPoints) {
+                            event.changes.forEach { pointerInputChange ->
+                                val pointerId = pointerInputChange.id.value
+                                if (pointerInputChange.pressed) {
+                                    // 이미 있는 포인터면 색상 유지, 없으면 랜덤 색상 할당
+                                    if (pointerId !in touchPoints) {
+                                        val availableColor =
+                                            pointColorList.filter { it !in usedColors }
+                                                .randomOrNull()
+                                        if (availableColor != null) {
+                                            usedColors.add(availableColor)
+                                            touchPoints[pointerId] =
+                                                pointerInputChange.position to availableColor
+                                        }
+                                    } else {
+                                        //기존 위치 업데이트
+                                        touchPoints[pointerId] =
+                                            pointerInputChange.position to touchPoints[pointerId]!!.second
+                                    }
+                                } else {
+                                    touchPoints[pointerId]?.second?.let { usedColors.remove(it) }
+                                    touchPoints.remove(pointerId)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+    ) {
+        // 현재 활성화된 각 터치에 대해 Point composable 표시
+        if (isGameActive) {
+            touchPoints.forEach { (_, data) ->
+                val (position, color) = data
+                // offset을 이용해 터치한 위치에 Point를 배치
+                CircleButton(
+                    modifier = modifier.offset {
+                        IntOffset(
+                            (position.x - (pointSize / 2).dp.toPx()).roundToInt(),
+                            (position.y - (pointSize / 2).dp.toPx()).roundToInt()
+                        )
+                    },
+                    pointSize = pointSize,
+                    color = color,
+                ) {
+
+                }
+            }
+        }
+        // 카운트다운 끝난 후 결과 Point 표시
+        resultPoints.forEach { (position, color) ->
+            CircleButton(
+                modifier = modifier.offset {
+                    IntOffset(
+                        (position.x - (pointSize / 2).dp.toPx()).roundToInt(),
+                        (position.y - (pointSize / 2).dp.toPx()).roundToInt()
+                    )
+                },
+                pointSize = pointSize,
+                color = color,
+            ) {
+            }
+        }
+        // 카운트다운 표시
+        countdown?.let {
+            Text(
+                text = it.toString(),
+                style = MaterialTheme.typography.displayLarge,
+                color = MaterialTheme.colorScheme.onPrimary,
+                modifier = modifier.align(Alignment.Center)
+            )
+        }
+
+        if (showResultDialog) {
+            resultDialog?.invoke(resetGame)
+        }
+    }
+
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun WTDGameComponentPreview() {
+    PickPointTheme(theme = AppTheme.LIGHT_PROTOTYPE, dynamicColor = false) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            WTDGameComponent(
+                resultDialog = { onRetry ->
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Button(
+                            onClick = { onRetry() },
+                            modifier = Modifier.align(Alignment.Center)
+                        ) {
+                            Text(
+                                "Retry",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onPrimary
+                            )
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -142,7 +142,7 @@ fun WTDGameComponent(
             }
         }
         // 카운트다운 끝난 후 결과 Point 표시
-        resultPoints.forEach { (position, color) ->
+        resultPoints.forEachIndexed { index, (position, color) ->
             CircleButton(
                 modifier = modifier.offset {
                     IntOffset(
@@ -152,6 +152,7 @@ fun WTDGameComponent(
                 },
                 pointSize = pointSize,
                 color = color,
+                number = index + 1
             ) {
             }
         }


### PR DESCRIPTION
## 변경 사항 요약
what to do에 사용할 게임 컴포넌트 작성

## 변경 사항
- [x] 파라미터로 넘겨준 total points만큼 터치가 가능하도록 구현
- [x] 결과 point에 숫자 표시


## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- resolves #28 


## 사용법 (이미지/동영상 등 필요시 첨부)

https://github.com/user-attachments/assets/a6117e98-043a-4820-9da7-ea85c2f1a6e6

- total points 만큼의 터치된 지점이 있는 경우에만 타이머가 시작되고, total points 만큼의 터치된 지점이 있는 경우에는 추가로 point 가 생성되지 않도록 구현


## 참고사항
- 이후에 단순히 색상만 있는 원이 아니라 point에 그림 같은걸 적용하는 경우에는 숫자가 잘 안보일 수도 있을 것 같아서 결과 리스트에 그림을 보여준다 하는 처리가 필요할 것 같기는 합니다
