### PR TITLE
[REFACTOR, FEAT] Button 정렬 수정, WTD에서 결과 복사 기능 추가

### DIFF
--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/Utils.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/Utils.kt
@@ -31,3 +31,18 @@ fun <T> List<T>.getRandomElements(count: Int): List<T> {
     return shuffledList.subList(0, count)
 }
 
+// WTD 결과를 string으로 변경
+fun List<String>.getResultString(): String{
+    if (this.isEmpty()) return ""
+
+    var result = "Results\n\n"
+    for (i in indices) {
+        if (i == this.size - 1){
+            // 마지막에는 \n 추가 안함
+            result += "${i+1}. "+this[i]
+        }else{
+            result += "${i+1}. "+this[i]+"\n"
+        }
+    }
+    return result
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerSettingComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerSettingComponent.kt
@@ -1,8 +1,10 @@
 package com.pickpoint.pickpoint.ui.randompicker.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -51,15 +53,18 @@ fun RandomPickerSettingContent(
 
         }
 
-        ResetConfirmButton(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 14.dp)
-                .padding(horizontal = 35.dp)
-                .align(Alignment.BottomCenter),
-            reset = { reset() },
-            apply = { apply() }
-        )
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 20.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            ResetConfirmButton(
+                reset = { reset() },
+                apply = { apply() }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerSettingContent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerSettingContent.kt
@@ -1,8 +1,10 @@
 package com.pickpoint.pickpoint.ui.teammaker.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -49,16 +51,18 @@ fun TeamMakerSettingContent(
             )
 
         }
-        ResetConfirmButton(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 14.dp)
-                .padding(horizontal = 35.dp)
-                .align(Alignment.BottomCenter),
-            reset = { reset() },
-            apply = { apply() }
-
-        )
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 20.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            ResetConfirmButton(
+                reset = { reset() },
+                apply = { apply() }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
@@ -1,5 +1,6 @@
 package com.pickpoint.pickpoint.ui.whattodo.component
 
+import android.content.ClipData
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -15,10 +16,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,8 +30,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pickpoint.pickpoint.R
 import com.pickpoint.pickpoint.ui.common.component.RetryButton
+import com.pickpoint.pickpoint.ui.common.util.getResultString
 import com.pickpoint.pickpoint.ui.theme.AppTheme
 import com.pickpoint.pickpoint.ui.theme.PickPointTheme
+import kotlinx.coroutines.launch
 
 @Composable
 fun WTDBottomSheetContent(
@@ -36,6 +42,9 @@ fun WTDBottomSheetContent(
     resultList: List<String>,
     retryClick: () -> Unit
 ) {
+    val clipboard = LocalClipboard.current
+    val coroutineScope = rememberCoroutineScope()
+
     Box(
         modifier = modifier
             .background(MaterialTheme.colorScheme.primary)
@@ -61,7 +70,11 @@ fun WTDBottomSheetContent(
                         .align(Alignment.CenterEnd)
                         .size(48.dp, 48.dp)
                         .clickable {
-
+                            val resultString = resultList.getResultString()
+                            val clipData = ClipData.newPlainText("Results", resultString)
+                            coroutineScope.launch {
+                                clipboard.setClipEntry(clipData.toClipEntry())
+                            }
                         }
                 ){
                     Icon(

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
@@ -1,14 +1,17 @@
 package com.pickpoint.pickpoint.ui.whattodo.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,10 +19,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.pickpoint.pickpoint.R
 import com.pickpoint.pickpoint.ui.common.component.RetryButton
 import com.pickpoint.pickpoint.ui.theme.AppTheme
 import com.pickpoint.pickpoint.ui.theme.PickPointTheme
@@ -41,12 +46,33 @@ fun WTDBottomSheetContent(
                 .fillMaxWidth()
                 .padding(horizontal = 30.dp)
         ) {
-            Text(
-                text = "Results",
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            )
+            Box(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "Results",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .size(48.dp, 48.dp)
+                        .clickable {
+
+                        }
+                ){
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_content_copy),
+                        contentDescription = "Copy",
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                    )
+                }
+            }
 
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDBottomSheetContent.kt
@@ -56,13 +56,13 @@ fun WTDBottomSheetContent(
                 .padding(horizontal = 30.dp)
         ) {
             Box(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = "Results",
                     style = MaterialTheme.typography.headlineLarge,
                     color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.align(Alignment.Center)
                 )
 
                 Box(
@@ -75,14 +75,13 @@ fun WTDBottomSheetContent(
                             coroutineScope.launch {
                                 clipboard.setClipEntry(clipData.toClipEntry())
                             }
-                        }
+                        },
+                    contentAlignment = Alignment.Center
                 ){
                     Icon(
                         painter = painterResource(id = R.drawable.ic_content_copy),
                         contentDescription = "Copy",
                         tint = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier
-                            .align(Alignment.Center)
                     )
                 }
             }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDSettingContent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDSettingContent.kt
@@ -1,8 +1,10 @@
 package com.pickpoint.pickpoint.ui.whattodo.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -61,15 +63,18 @@ fun WTDSettingContent(
             )
         }
 
-        ResetConfirmButton(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 14.dp)
-                .padding(horizontal = 20.dp)
-                .align(Alignment.BottomCenter),
-            reset = { reset() },
-            apply = { confirm() }
-        )
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 20.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            ResetConfirmButton(
+                reset = { reset() },
+                apply = { confirm() }
+            )
+        }
     }
 }
 

--- a/app/src/main/res/drawable/ic_content_copy.xml
+++ b/app/src/main/res/drawable/ic_content_copy.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,720q-33,0 -56.5,-23.5T280,640v-480q0,-33 23.5,-56.5T360,80h360q33,0 56.5,23.5T800,160v480q0,33 -23.5,56.5T720,720L360,720ZM360,640h360v-480L360,160v480ZM200,880q-33,0 -56.5,-23.5T120,800v-560h80v560h440v80L200,880ZM360,640v-480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
## 변경 사항 요약
ResetConfirm 버튼 정렬 수정, WTD에서 결과 클립보드에 복사하는 기능 추가

## 변경 사항
- [x] WTD에서의 결과를 String으로 변경하는 확장함수 추가
- [x] 각 게임 설정 화면에서의 하단 버튼 정렬 수정, 하단 padding 추가
- [x] WTD 결과 화면에서 결과를 클립보드에 복사하는 아이콘, 기능 추가


## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- resoves #48 


## 사용법 (이미지/동영상 등 필요시 첨부)

https://github.com/user-attachments/assets/c5a8f238-b0f4-41ae-9449-2cf6d58dfd75




## 참고사항
- 
