### PR TITLE
[FEAT] 터치된 점이 없으면 TapToStart를 띄우는 기능 구현

### DIFF
--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/TapToStartComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/TapToStartComponent.kt
@@ -1,0 +1,42 @@
+package com.pickpoint.pickpoint.ui.common.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.pickpoint.pickpoint.ui.theme.AppTheme
+import com.pickpoint.pickpoint.ui.theme.PickPointTheme
+
+@Composable
+fun TapToStartComponent(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Tap to Start!",
+            color = MaterialTheme.colorScheme.onPrimary,
+            style = MaterialTheme.typography.displayLarge
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TapToStartComponentPreview() {
+    PickPointTheme(theme = AppTheme.LIGHT_PROTOTYPE, dynamicColor = false) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TapToStartComponent()
+        }
+    }
+}

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/TapToStartComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/component/TapToStartComponent.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.pickpoint.pickpoint.R
 import com.pickpoint.pickpoint.ui.theme.AppTheme
 import com.pickpoint.pickpoint.ui.theme.PickPointTheme
 
@@ -20,7 +22,7 @@ fun TapToStartComponent(modifier: Modifier = Modifier) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "Tap to Start!",
+            text = stringResource(R.string.tap_to_start),
             color = MaterialTheme.colorScheme.onPrimary,
             style = MaterialTheme.typography.displayLarge
         )

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
@@ -90,7 +90,7 @@ fun RandomPickerGameComponent(
     }
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             // pointerInput을 이용해 터치 이벤트를 감지
@@ -124,19 +124,33 @@ fun RandomPickerGameComponent(
                 }
             }
     ) {
-        // 게임 시작 전 Tap to Start 표시
-        if (touchPoints.isEmpty() && isGameActive){
-            TapToStartComponent(
-                modifier = modifier
-                    .align(Alignment.Center)
-            )
-        }
+            // 게임 시작 전 Tap to Start 표시
+            if (touchPoints.isEmpty() && isGameActive) {
+                TapToStartComponent(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                )
+            }
 
-        // 현재 활성화된 각 터치에 대해 Point composable 표시
-        if (isGameActive) {
-            touchPoints.forEach { (_, data) ->
-                val (position, color) = data
-                // offset을 이용해 터치한 위치에 Point를 배치
+            // 현재 활성화된 각 터치에 대해 Point composable 표시
+            if (isGameActive) {
+                touchPoints.forEach { (_, data) ->
+                    val (position, color) = data
+                    // offset을 이용해 터치한 위치에 Point를 배치
+                    CircleButton(
+                        modifier = Modifier.offset {
+                            IntOffset(
+                                (position.x - (pointSize / 2).dp.toPx()).roundToInt(),
+                                (position.y - (pointSize / 2).dp.toPx()).roundToInt()
+                            )
+                        },
+                        pointSize = pointSize,
+                        color = color,
+                    )
+                }
+            }
+            // 카운트다운 끝난 후 결과 Point 표시
+            resultPoints.forEach { (position, color) ->
                 CircleButton(
                     modifier = Modifier.offset {
                         IntOffset(
@@ -148,35 +162,19 @@ fun RandomPickerGameComponent(
                     color = color,
                 )
             }
-        }
-        // 카운트다운 끝난 후 결과 Point 표시
-        resultPoints.forEach { (position, color) ->
-            CircleButton(
-                modifier = Modifier.offset {
-                    IntOffset(
-                        (position.x - (pointSize / 2).dp.toPx()).roundToInt(),
-                        (position.y - (pointSize / 2).dp.toPx()).roundToInt()
-                    )
-                },
-                pointSize = pointSize,
-                color = color,
-            )
-        }
-        // 카운트다운 표시
-        countdown?.let {
-            Text(
-                text = it.toString(),
-                style = MaterialTheme.typography.displayLarge,
-                color = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.align(Alignment.Center)
-            )
-        }
-
-        if (showResultDialog) {
-            resultDialog?.invoke(resetGame)
-        }
+            // 카운트다운 표시
+            countdown?.let {
+                Text(
+                    text = it.toString(),
+                    style = MaterialTheme.typography.displayLarge,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            if (showResultDialog) {
+                resultDialog?.invoke(resetGame)
+            }
     }
-
 }
 
 

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.pickpoint.pickpoint.R
 import com.pickpoint.pickpoint.ui.common.component.CircleButton
+import com.pickpoint.pickpoint.ui.common.component.TapToStartComponent
 import com.pickpoint.pickpoint.ui.common.util.getPointColorList
 import com.pickpoint.pickpoint.ui.common.util.timerStartHandler
 import com.pickpoint.pickpoint.ui.theme.AppTheme
@@ -123,6 +124,14 @@ fun RandomPickerGameComponent(
                 }
             }
     ) {
+        // 게임 시작 전 Tap to Start 표시
+        if (touchPoints.isEmpty() && isGameActive){
+            TapToStartComponent(
+                modifier = modifier
+                    .align(Alignment.Center)
+            )
+        }
+
         // 현재 활성화된 각 터치에 대해 Point composable 표시
         if (isGameActive) {
             touchPoints.forEach { (_, data) ->

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
@@ -101,7 +101,7 @@ fun TeamMakerGameComponent(
     }
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             // pointerInput을 이용해 터치 이벤트를 감지
@@ -138,7 +138,7 @@ fun TeamMakerGameComponent(
         // 게임 시작 전 Tap to Start 표시
         if (touchPoints.isEmpty() && isGameActive){
             TapToStartComponent(
-                modifier = modifier
+                modifier = Modifier
                     .align(Alignment.Center)
             )
         }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.pickpoint.pickpoint.R
 import com.pickpoint.pickpoint.ui.common.component.CircleButton
+import com.pickpoint.pickpoint.ui.common.component.TapToStartComponent
 import com.pickpoint.pickpoint.ui.common.util.getPointColorList
 import com.pickpoint.pickpoint.ui.common.util.timerStartHandler
 import com.pickpoint.pickpoint.ui.theme.AppTheme
@@ -134,6 +135,14 @@ fun TeamMakerGameComponent(
                 }
             }
     ) {
+        // 게임 시작 전 Tap to Start 표시
+        if (touchPoints.isEmpty() && isGameActive){
+            TapToStartComponent(
+                modifier = modifier
+                    .align(Alignment.Center)
+            )
+        }
+
         // 현재 활성화된 각 터치에 대해 Point composable 표시
         if (isGameActive) {
             touchPoints.forEach { (_, data) ->

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.pickpoint.pickpoint.ui.common.component.CircleButton
+import com.pickpoint.pickpoint.ui.common.component.TapToStartComponent
 import com.pickpoint.pickpoint.ui.common.util.getPointColorList
 import com.pickpoint.pickpoint.ui.common.util.timerStartHandler
 import com.pickpoint.pickpoint.ui.theme.AppTheme
@@ -124,6 +125,14 @@ fun WTDGameComponent(
                 }
             }
     ) {
+        // 게임 시작 전 Tap to Start 표시
+        if (touchPoints.isEmpty() && isGameActive){
+            TapToStartComponent(
+                modifier = modifier
+                    .align(Alignment.Center)
+            )
+        }
+
         // 현재 활성화된 각 터치에 대해 Point composable 표시
         if (isGameActive) {
             touchPoints.forEach { (_, data) ->

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -88,7 +88,7 @@ fun WTDGameComponent(
     }
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             // pointerInput을 이용해 터치 이벤트를 감지

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,5 +40,6 @@
     <!-- Screen -->
     <string name="game_settings">Game Settings</string>
     <string name="total_teams">Total Teams</string>
+    <string name="tap_to_start">Tap to Start!</string>
 
 </resources>


### PR DESCRIPTION
## 변경 사항 요약
각 게임에서 화면에 터치된 점이 없으면 TapToStart를 화면에 띄우도록 구현

## 변경 사항
- [x] 화면에 터치된 점이 없으면 TapToStartComponent를 표시
- [x] game component에서의 modifier 수정하여 컴포넌트 정렬 수정


## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- resolves #54


## 사용법 (이미지/동영상 등 필요시 첨부)

https://github.com/user-attachments/assets/f9a0a99a-d1b1-423a-8690-b90649c31fae


## 참고사항
- 
