### PR TITLE
[FIX] WTD 화면 버그 수정 , 카운트 시작까지 시간 축소

### DIFF
--- a/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/TimerStartHandler.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/common/util/TimerStartHandler.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun timerStartHandler(
     pointsToStart: Int = 2, // 시작하기 위한 포인트 개수
-    timeToStart: Long = 2000, // 시작하기 위한 시간 (ms)
+    timeToStart: Long = 1000, // 시작하기 위한 시간 (ms)
 ): Pair<SnapshotStateMap<Long, Pair<Offset, Color>>, SnapshotStateList<Pair<Offset, Color>>> {
     val touchPoints = remember { mutableStateMapOf<Long, Pair<Offset, Color>>() }
     val finalPoints = remember { mutableStateListOf<Pair<Offset, Color>>() }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/randompicker/component/RandomPickerGameComponent.kt
@@ -44,7 +44,7 @@ fun RandomPickerGameComponent(
 ) {
     val pointColorList = LocalPointColors.current.getPointColorList()
     val pointSize = 100
-    val timeToStart: Long = 2000 //2초
+    val timeToStart: Long = 1000 //2초
     val usedColors = remember { mutableStateListOf<Color>() }
     var countdown by remember { mutableStateOf<Int?>(null) }
     var isGameActive by remember { mutableStateOf(true) } // 게임 진행 여부

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/teammaker/component/TeamMakerGameComponent.kt
@@ -43,7 +43,7 @@ fun TeamMakerGameComponent(
 ) {
     val pointColorList = LocalPointColors.current.getPointColorList()
     val pointSize = 100
-    val timeToStart: Long = 2000 //2초
+    val timeToStart: Long = 1000 //2초
     val usedColors = remember { mutableStateListOf<Color>() }
     val teamColors = remember { mutableStateListOf<Color>() }
     var countdown by remember { mutableStateOf<Int?>(null) }

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -1,5 +1,6 @@
 package com.pickpoint.pickpoint.ui.whattodo.component
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -96,29 +97,28 @@ fun WTDGameComponent(
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent()
-                        if (event.changes.size <= totalPoints) {
-                            event.changes.forEach { pointerInputChange ->
-                                val pointerId = pointerInputChange.id.value
-                                if (pointerInputChange.pressed) {
-                                    // 이미 있는 포인터면 색상 유지, 없으면 랜덤 색상 할당
-                                    if (pointerId !in touchPoints) {
-                                        val availableColor =
-                                            pointColorList.filter { it !in usedColors }
-                                                .randomOrNull()
-                                        if (availableColor != null) {
-                                            usedColors.add(availableColor)
-                                            touchPoints[pointerId] =
-                                                pointerInputChange.position to availableColor
-                                        }
-                                    } else {
-                                        //기존 위치 업데이트
+                        event.changes.take(totalPoints).forEach { pointerInputChange ->
+                            Log.d("eventchange", "eventchange: ${pointerInputChange.id.value})")
+                            val pointerId = pointerInputChange.id.value
+                            if (pointerInputChange.pressed) {
+                                // 이미 있는 포인터면 색상 유지, 없으면 랜덤 색상 할당
+                                if (pointerId !in touchPoints) {
+                                    val availableColor =
+                                        pointColorList.filter { it !in usedColors }
+                                            .randomOrNull()
+                                    if (availableColor != null) {
+                                        usedColors.add(availableColor)
                                         touchPoints[pointerId] =
-                                            pointerInputChange.position to touchPoints[pointerId]!!.second
+                                            pointerInputChange.position to availableColor
                                     }
                                 } else {
-                                    touchPoints[pointerId]?.second?.let { usedColors.remove(it) }
-                                    touchPoints.remove(pointerId)
+                                    //기존 위치 업데이트
+                                    touchPoints[pointerId] =
+                                        pointerInputChange.position to touchPoints[pointerId]!!.second
                                 }
+                            } else {
+                                touchPoints[pointerId]?.second?.let { usedColors.remove(it) }
+                                touchPoints.remove(pointerId)
                             }
                         }
                     }
@@ -126,7 +126,7 @@ fun WTDGameComponent(
             }
     ) {
         // 게임 시작 전 Tap to Start 표시
-        if (touchPoints.isEmpty() && isGameActive){
+        if (touchPoints.isEmpty() && isGameActive) {
             TapToStartComponent(
                 modifier = modifier
                     .align(Alignment.Center)
@@ -135,8 +135,7 @@ fun WTDGameComponent(
 
         // 현재 활성화된 각 터치에 대해 Point composable 표시
         if (isGameActive) {
-            touchPoints.forEach { (_, data) ->
-                val (position, color) = data
+            touchPoints.values.take(totalPoints).forEach { (position, color) ->
                 // offset을 이용해 터치한 위치에 Point를 배치
                 CircleButton(
                     modifier = Modifier.offset {

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -97,8 +97,8 @@ fun WTDGameComponent(
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent()
+
                         event.changes.take(totalPoints).forEach { pointerInputChange ->
-                            Log.d("eventchange", "eventchange: ${pointerInputChange.id.value})")
                             val pointerId = pointerInputChange.id.value
                             if (pointerInputChange.pressed) {
                                 // 이미 있는 포인터면 색상 유지, 없으면 랜덤 색상 할당
@@ -135,7 +135,7 @@ fun WTDGameComponent(
 
         // 현재 활성화된 각 터치에 대해 Point composable 표시
         if (isGameActive) {
-            touchPoints.values.take(totalPoints).forEach { (position, color) ->
+            touchPoints.values.forEach { (position, color) ->
                 // offset을 이용해 터치한 위치에 Point를 배치
                 CircleButton(
                     modifier = Modifier.offset {

--- a/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
+++ b/app/src/main/java/com/pickpoint/pickpoint/ui/whattodo/component/WTDGameComponent.kt
@@ -42,7 +42,7 @@ fun WTDGameComponent(
 ) {
     val pointColorList = LocalPointColors.current.getPointColorList()
     val pointSize = 100
-    val timeToStart: Long = 2000 //2초
+    val timeToStart: Long = 1000 //2초
     val usedColors = remember { mutableStateListOf<Color>() }
     var countdown by remember { mutableStateOf<Int?>(null) }
     var isGameActive by remember { mutableStateOf(true) } // 게임 진행 여부


### PR DESCRIPTION
## 변경 사항 요약
- WTD 화면엔 포인트 남아있는 버그 수정
- 카운트 시작까지 시간 축소

## 변경 사항
- [x] 터치 이벤트 개수를 4개만 측정하도록 수정
- [x] 카운트 시작까지 시간 2000 -> 1000 으로 수정


## 연관된 issue 번호(#issue번호 or resolves #issue번호)
merge시에 issue가 해결되면 resolves와 함께 작성
- closed #61 


## 사용법 (이미지/동영상 등 필요시 첨부)
- 

https://github.com/user-attachments/assets/6262ce02-ae58-4a31-b471-64e56b36d43c




## 참고사항
- 
